### PR TITLE
Update Grafana dashboard with current memory metric names.

### DIFF
--- a/scripts/grafana_dashboard.json
+++ b/scripts/grafana_dashboard.json
@@ -62,18 +62,18 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "dgraph_memory_inuse_bytes+dgraph_heap_idle_bytes{instance=~'$Instance'}",
+              "expr": "dgraph_memory_inuse_bytes+dgraph_memory_idle_bytes{instance=~'$Instance'}",
               "intervalFactor": 2,
               "legendFormat": "",
-              "metric": "dgraph_heap_idle_bytes",
+              "metric": "dgraph_memory_idle_bytes",
               "refId": "A",
               "step": 2
             },
             {
-              "expr": "dgraph_proc_memory_bytes{instance=~'$Instance'}",
+              "expr": "dgraph_memory_proc_bytes{instance=~'$Instance'}",
               "intervalFactor": 2,
               "legendFormat": "",
-              "metric": "dgraph_proc_memory_bytes",
+              "metric": "dgraph_memory_proc_bytes",
               "refId": "B",
               "step": 2
             }


### PR DESCRIPTION
As of https://github.com/dgraph-io/dgraph/pull/2636, the memory metric names for "dgraph_heap_idle_bytes" and "dgraph_proc_memory_bytes" are now "dgraph_memory_idle_bytes" and "dgraph_memory_proc_bytes".

This PR updates the Grafana dashboard template with the updated names. It should be merged once this change is released in v1.0.10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/benchmarks/10)
<!-- Reviewable:end -->
