### PR TITLE
Adding @lang to two additional fields

### DIFF
--- a/data/21million.schema
+++ b/data/21million.schema
@@ -10,3 +10,4 @@ starring             : uid @count .
 _share_hash_         : string @index(exact) .
 performance.character_note: string @lang .
 tagline              : string @lang .
+cut.note             : string @lang .

--- a/data/21million.schema
+++ b/data/21million.schema
@@ -8,3 +8,5 @@ loc                  : geo @index(geo) .
 name                 : string @index(hash, fulltext, trigram) @lang .
 starring             : uid @count .
 _share_hash_         : string @index(exact) .
+performance.character_note: string @lang .
+tagline              : string @lang .


### PR DESCRIPTION
In the 21million.rdf.gz data file, some lines have the language tag for the performance.character_once or tagline predicate.
Without the @lang support in the schema file, those lines cannot be loaded to dgraph.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/benchmarks/11)
<!-- Reviewable:end -->
