### PR TITLE
Specify @lang schema for predicates in release.schema.

### DIFF
--- a/data/release/release.schema
+++ b/data/release/release.schema
@@ -8,4 +8,7 @@ loc                  : geo @index(geo) .
 name                 : string @index(hash, term, trigram) @lang .
 starring             : uid .
 _share_hash_         : string @index(hash) .
+performance.character_note: string @lang .
+tagline              : string @lang .
+cut.note             : string @lang .
 rated		     : uid @reverse .


### PR DESCRIPTION
Needed with new @lang schema handling or else this error shows up during bulk loading:

```
2018/11/08 11:47:34 RDF doesn't match schema: Attr: [performance.character_note] should have @lang directive in schema to mutate edge: [entity:2380001 attr:"performance.character_note" value:"Page to Count Almaviva" lang:"en" ]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/benchmarks/12)
<!-- Reviewable:end -->
