### PR TITLE
Sync Schemas and add pred "email"

### DIFF
--- a/data/21million.schema
+++ b/data/21million.schema
@@ -1,12 +1,12 @@
 director.film        : [uid] @reverse @count .
-actor.film           : [uid] .
+actor.film           : [uid] @count .
 genre                : [uid] @reverse @count .
 initial_release_date : datetime @index(year) .
 rating               : [uid] @reverse .
 country              : [uid] @reverse .
 loc                  : geo @index(geo) .
 name                 : string @index(hash, term, trigram, fulltext) @lang .
-starring             : [uid] .
+starring             : [uid] @count .
 _share_hash_         : string @index(hash) .
 performance.character_note : string @lang .
 tagline              : string @lang .

--- a/data/21million.schema
+++ b/data/21million.schema
@@ -1,15 +1,16 @@
 director.film        : [uid] @reverse @count .
-actor.film           : [uid] @count .
+actor.film           : [uid] .
 genre                : [uid] @reverse @count .
 initial_release_date : datetime @index(year) .
 rating               : [uid] @reverse .
 country              : [uid] @reverse .
 loc                  : geo @index(geo) .
-name                 : string @index(hash, fulltext, trigram, term) @lang .
-starring             : [uid] @count .
-_share_hash_         : string @index(exact) .
-performance.character_note: string @lang .
+name                 : string @index(hash, term, trigram, fulltext) @lang .
+starring             : [uid] .
+_share_hash_         : string @index(hash) .
+performance.character_note : string @lang .
 tagline              : string @lang .
 cut.note             : string @lang .
-rated	    	     : [uid] @reverse .
-email	    	     : string @index(exact) @upsert .
+rated                : [uid] @reverse .
+email                : string @index(exact) @upsert .
+

--- a/data/21million.schema
+++ b/data/21million.schema
@@ -11,3 +11,5 @@ _share_hash_         : string @index(exact) .
 performance.character_note: string @lang .
 tagline              : string @lang .
 cut.note             : string @lang .
+rated	    	     : [uid] @reverse .
+email	    	     : string @index(exact) @upsert .

--- a/data/panama.schema
+++ b/data/panama.schema
@@ -5,3 +5,4 @@ node_id: string @index(exact) .
 type: [uid] @reverse .
 hasCountry: [uid] @reverse .
 incorporation_date: date @index .
+

--- a/data/panama.schema
+++ b/data/panama.schema
@@ -1,7 +1,7 @@
-name:string @index(exact,term,trigram) .
-original_name:string @index(exact,term,trigram) .
-former_name:string @index(exact,term,trigram) .
-node_id:string @index(exact) .
-type:uid @reverse .
-hasCountry:uid @reverse .
-incorporation_date:date @index .
+name: string @index(exact,term,trigram) .
+original_name: string @index(exact,term,trigram) .
+former_name: string @index(exact,term,trigram) .
+node_id: string @index(exact) .
+type: [uid] @reverse .
+hasCountry: [uid] @reverse .
+incorporation_date: date @index .

--- a/data/release/release.schema
+++ b/data/release/release.schema
@@ -1,12 +1,12 @@
 director.film        : [uid] @reverse @count .
-actor.film           : [uid] .
+actor.film           : [uid] @count .
 genre                : [uid] @reverse @count .
 initial_release_date : datetime @index(year) .
 rating               : [uid] @reverse .
 country              : [uid] @reverse .
 loc                  : geo @index(geo) .
 name                 : string @index(hash, term, trigram, fulltext) @lang .
-starring             : [uid] .
+starring             : [uid] @count .
 _share_hash_         : string @index(hash) .
 performance.character_note : string @lang .
 tagline              : string @lang .

--- a/data/release/release.schema
+++ b/data/release/release.schema
@@ -1,14 +1,15 @@
-director.film        : uid @reverse @count .
-actor.film           : uid .
-genre                : uid @reverse @count .
+director.film        : [uid] @reverse @count .
+actor.film           : [uid] .
+genre                : [uid] @reverse @count .
 initial_release_date : datetime @index(year) .
-rating               : uid @reverse .
-country              : uid @reverse .
+rating               : [uid] @reverse .
+country              : [uid] @reverse .
 loc                  : geo @index(geo) .
 name                 : string @index(hash, term, trigram, fulltext) @lang .
-starring             : uid .
+starring             : [uid] .
 _share_hash_         : string @index(hash) .
 performance.character_note: string @lang .
 tagline              : string @lang .
 cut.note             : string @lang .
-rated		     : uid @reverse .
+rated	    	     : [uid] @reverse .
+email	    	     : string @index(exact) @upsert .

--- a/data/release/release.schema
+++ b/data/release/release.schema
@@ -8,8 +8,9 @@ loc                  : geo @index(geo) .
 name                 : string @index(hash, term, trigram, fulltext) @lang .
 starring             : [uid] .
 _share_hash_         : string @index(hash) .
-performance.character_note: string @lang .
+performance.character_note : string @lang .
 tagline              : string @lang .
 cut.note             : string @lang .
-rated	    	     : [uid] @reverse .
-email	    	     : string @index(exact) @upsert .
+rated                : [uid] @reverse .
+email                : string @index(exact) @upsert .
+


### PR DESCRIPTION
Just by synchronizing schemas and adding the "email" predicate to the schemas.

The reason for the pred "email" is in case a Play Dgraph user comes to test "upsert" on it. It does not receive errors like ": Attribute email is not indexed."

At RDF 21milion you have 2 emails `sfdowntown@hiusa.org` and `reservations@hotelgriffon.com`. That is, this change does not change anything significant. And it could be used in place of "`bob@example.com`" in docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/benchmarks/15)
<!-- Reviewable:end -->
