### PR TITLE
dropping _share_hash_ from all schemas

### DIFF
--- a/data/21million-noindex.schema
+++ b/data/21million-noindex.schema
@@ -7,7 +7,6 @@ country              : [uid] .
 loc                  : geo .
 name                 : string @lang .
 starring             : [uid] .
-_share_hash_         : string .
 performance.character_note : string @lang .
 tagline              : string @lang .
 cut.note             : string @lang .

--- a/data/21million.schema
+++ b/data/21million.schema
@@ -7,7 +7,6 @@ country              : [uid] @reverse .
 loc                  : geo @index(geo) .
 name                 : string @index(hash, term, trigram, fulltext) @lang .
 starring             : [uid] @count .
-_share_hash_         : string @index(hash) .
 performance.character_note : string @lang .
 tagline              : string @lang .
 cut.note             : string @lang .

--- a/data/release/release.schema
+++ b/data/release/release.schema
@@ -7,7 +7,6 @@ country              : [uid] @reverse .
 loc                  : geo @index(geo) .
 name                 : string @index(hash, term, trigram, fulltext) @lang .
 starring             : [uid] @count .
-_share_hash_         : string @index(hash) .
 performance.character_note : string @lang .
 tagline              : string @lang .
 cut.note             : string @lang .


### PR DESCRIPTION
This is not necessary now that we have removed the `share` functionality from Dgraph.

See https://github.com/dgraph-io/dgraph/pull/3640

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/benchmarks/25)
<!-- Reviewable:end -->
